### PR TITLE
Add legal pages and cookie consent

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,11 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import Events from "./pages/Events";
 import Blog from "./pages/Blog";
+import Privacy from "./pages/Privacy";
+import Terms from "./pages/Terms";
+import CookiesPage from "./pages/Cookies";
 import NotFound from "./pages/NotFound";
+import CookieConsentBanner from "./components/CookieConsentBanner";
 
 const queryClient = new QueryClient();
 
@@ -21,9 +25,13 @@ const App = () => (
           <Route path="/" element={<Index />} />
           <Route path="/events" element={<Events />} />
           <Route path="/blog" element={<Blog />} />
+          <Route path="/privacy" element={<Privacy />} />
+          <Route path="/terms" element={<Terms />} />
+          <Route path="/cookies" element={<CookiesPage />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>
+        <CookieConsentBanner />
       </BrowserRouter>
     </TooltipProvider>
   </QueryClientProvider>

--- a/src/components/CookieConsentBanner.tsx
+++ b/src/components/CookieConsentBanner.tsx
@@ -1,0 +1,38 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+
+const CookieConsentBanner = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const consent = localStorage.getItem('cookie_consent');
+    if (!consent) {
+      setVisible(true);
+    }
+  }, []);
+
+  const accept = () => {
+    localStorage.setItem('cookie_consent', 'true');
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed bottom-0 inset-x-0 z-50 bg-rosy-navy text-white p-4 flex flex-col md:flex-row items-center justify-between space-y-2 md:space-y-0">
+      <p>
+        We use cookies to enhance your experience.{' '}
+        <Link to="/cookies" className="underline">
+          Learn more
+        </Link>
+        .
+      </p>
+      <Button onClick={accept} className="bg-rosy-teal hover:bg-rosy-teal/90 text-white">
+        Accept
+      </Button>
+    </div>
+  );
+};
+
+export default CookieConsentBanner;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,6 @@
 
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 const Footer = () => {
   return (
@@ -17,7 +18,21 @@ const Footer = () => {
               <p>Austin, TX 78701</p>
               <p className="mt-4">hello@rosyrooftopbar.com</p>
               <p>rosyrooftopbar.com</p>
-              <p className="mt-4">Privacy Policy</p>
+              <p className="mt-4">
+                <Link to="/privacy" className="underline hover:text-rosy-teal">
+                  Privacy Policy
+                </Link>
+              </p>
+              <p>
+                <Link to="/terms" className="underline hover:text-rosy-teal">
+                  Terms of Service
+                </Link>
+              </p>
+              <p>
+                <Link to="/cookies" className="underline hover:text-rosy-teal">
+                  Cookie Policy
+                </Link>
+              </p>
             </div>
           </div>
           

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -81,8 +81,10 @@ const SidebarProvider = React.forwardRef<
           _setOpen(openState)
         }
 
-        // This sets the cookie to keep the sidebar state.
-        document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`
+        // This sets the cookie to keep the sidebar state only after consent.
+        if (localStorage.getItem('cookie_consent') === 'true') {
+          document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}; SameSite=Lax; Secure`
+        }
       },
       [setOpenProp, open]
     )

--- a/src/pages/Cookies.tsx
+++ b/src/pages/Cookies.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import Header from '@/components/Header';
+import Footer from '@/components/Footer';
+
+const CookiesPage = () => (
+  <div className="min-h-screen bg-background">
+    <Header />
+    <main className="container mx-auto px-4 sm:px-6 lg:px-8 py-20">
+      <h1 className="text-4xl md:text-5xl font-playfair font-bold text-rosy-navy mb-6">
+        Cookie Policy
+      </h1>
+      <p className="text-muted-foreground space-y-4">
+        <span>This is placeholder text for the cookie policy.</span>
+      </p>
+    </main>
+    <Footer />
+  </div>
+);
+
+export default CookiesPage;

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import Header from '@/components/Header';
+import Footer from '@/components/Footer';
+
+const Privacy = () => (
+  <div className="min-h-screen bg-background">
+    <Header />
+    <main className="container mx-auto px-4 sm:px-6 lg:px-8 py-20">
+      <h1 className="text-4xl md:text-5xl font-playfair font-bold text-rosy-navy mb-6">
+        Privacy Policy
+      </h1>
+      <p className="text-muted-foreground space-y-4">
+        <span>This is placeholder text for the privacy policy.</span>
+      </p>
+    </main>
+    <Footer />
+  </div>
+);
+
+export default Privacy;

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import Header from '@/components/Header';
+import Footer from '@/components/Footer';
+
+const Terms = () => (
+  <div className="min-h-screen bg-background">
+    <Header />
+    <main className="container mx-auto px-4 sm:px-6 lg:px-8 py-20">
+      <h1 className="text-4xl md:text-5xl font-playfair font-bold text-rosy-navy mb-6">
+        Terms of Service
+      </h1>
+      <p className="text-muted-foreground space-y-4">
+        <span>This is placeholder text for the terms of service.</span>
+      </p>
+    </main>
+    <Footer />
+  </div>
+);
+
+export default Terms;


### PR DESCRIPTION
## Summary
- create placeholder legal pages
- update footer with legal links
- show a cookie consent banner on first visit
- set sidebar cookie only after consent with security flags
- wire new pages into router

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_68628cff29748320830bcde57c1a40c0