### PR TITLE
Improve contrast for accessibility

### DIFF
--- a/src/components/FeaturesSection.tsx
+++ b/src/components/FeaturesSection.tsx
@@ -53,10 +53,10 @@ const FeaturesSection = () => {
                 <h3 className="text-2xl font-playfair font-bold text-rosy-navy mb-4">
                   {feature.title}
                 </h3>
-                <p className="text-rosy-navy/80 font-inter mb-6 leading-relaxed">
+                <p className="text-rosy-navy font-inter mb-6 leading-relaxed">
                   {feature.description}
                 </p>
-                <Button className={`${feature.buttonStyle} text-white rounded-full px-6 py-2`}>
+                <Button className={`${feature.buttonStyle} text-rosy-navy rounded-full px-6 py-2`}>
                   {feature.buttonText}
                 </Button>
               </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -50,7 +50,7 @@ const Header = () => {
             </Link>
           </nav>
 
-          <Button className="hidden md:inline-flex bg-rosy-teal hover:bg-rosy-teal/90 text-white">
+          <Button className="hidden md:inline-flex bg-rosy-teal hover:bg-rosy-teal/90 text-rosy-navy">
             RESERVE A TABLE
           </Button>
 
@@ -91,7 +91,7 @@ const Header = () => {
               >
                 BLOG
               </Link>
-              <Button className="bg-rosy-teal hover:bg-rosy-teal/90 text-white w-fit">
+              <Button className="bg-rosy-teal hover:bg-rosy-teal/90 text-rosy-navy w-fit">
                 RESERVE A TABLE
               </Button>
             </nav>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -11,7 +11,7 @@ const HeroSection = () => {
           backgroundImage: `url('/lovable-uploads/7cb26fe8-e325-48ac-9ed5-b6404609ab84.png')`
         }}
       >
-        <div className="absolute inset-0 bg-black/40"></div>
+        <div className="absolute inset-0 bg-black/60"></div>
       </div>
       
       <div className="relative z-10 text-center text-white px-4 sm:px-6 lg:px-8 animate-fade-in">
@@ -26,7 +26,7 @@ const HeroSection = () => {
         <div className="bg-rosy-cream/95 text-rosy-navy p-8 sm:p-12 rounded-2xl max-w-5xl mx-auto shadow-2xl backdrop-blur-sm">
           <h1 className="text-4xl sm:text-6xl md:text-7xl font-playfair font-bold mb-6 leading-tight">
             ELEVATE YOUR<br/>
-            <span className="text-rosy-teal">EXPERIENCE</span>
+            <span className="text-rosy-navy">EXPERIENCE</span>
           </h1>
           
           <p className="text-lg sm:text-xl font-inter mb-8 max-w-4xl mx-auto leading-relaxed">
@@ -36,7 +36,7 @@ const HeroSection = () => {
             cobblestone streets, Hudson River sunsets, and the iconic Whitney Museum.
           </p>
           
-          <Button size="lg" className="bg-rosy-teal hover:bg-rosy-teal/90 text-white text-lg px-8 py-4 rounded-full font-semibold">
+          <Button size="lg" className="bg-rosy-teal hover:bg-rosy-teal/90 text-rosy-navy text-lg px-8 py-4 rounded-full font-semibold">
             RESERVE A TABLE
           </Button>
         </div>

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,8 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps =
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -125,5 +126,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- darken CTA button text in Header and Hero sections
- darken overlay and highlight text in HeroSection
- use darker foregrounds in FeaturesSection
- fix lint issues in command and textarea components
- switch Tailwind config to ESM plugin import

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68628d2859388320a12857eabcae94e2